### PR TITLE
Mobile responsive fix

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -12,7 +12,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
   return (
     <div className="x:pb-[env(safe-area-inset-bottom)] x:print:bg-transparent">
       <Switchers>
-        <div className="x:mx-auto x:flex x:max-w-(--nextra-content-width) x:gap-2 x:py-2 x:px-4">
+        <div className="x:mx-auto x:flex x:md:max-w-(--nextra-content-width) x:max-w-screen x:gap-2 x:py-2 x:px-4">
           <LocaleSwitch />
           <ThemeSwitch />
         </div>
@@ -21,7 +21,7 @@ export const Footer: FC<ComponentProps<'footer'>> = ({
       {children && (
         <footer
           className={cn(
-            'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
+            'x:mx-auto x:flex x:md:max-w-(--nextra-content-width) x:max-w-screen x:justify-center x:py-12 x:text-gray-600 x:dark:text-gray-400 x:md:justify-start',
             'x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
             className
           )}

--- a/src/components/navbar/index.tsx
+++ b/src/components/navbar/index.tsx
@@ -63,7 +63,7 @@ export const Navbar: FC<NavbarProps> = props => {
       <nav
         style={{ height: 'var(--nextra-navbar-height)' }}
         className={cn(
-          'x:mx-auto x:flex x:max-w-(--nextra-content-width) x:items-center x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
+          'x:mx-auto x:flex x:md:max-w-(--nextra-content-width) x:max-w-screen x:items-center x:gap-4 x:pl-[max(env(safe-area-inset-left),1.5rem)] x:pr-[max(env(safe-area-inset-right),1.5rem)]',
           'x:justify-end',
           className
         )}

--- a/src/mdx-components/index.tsx
+++ b/src/mdx-components/index.tsx
@@ -91,7 +91,7 @@ const DEFAULT_COMPONENTS = getNextraMDXComponents({
     }))
     return (
       <div
-        className="x:mx-auto x:flex x:max-w-(--nextra-content-width)"
+        className="x:mx-auto x:flex x:md:max-w-(--nextra-content-width) x:max-w-screen"
         // Attach user-defined props to wrapper container, e.g. `data-pagefind-filter`
         {...props}
       >


### PR DESCRIPTION
|before|after|
|---|---|
|<img width="356" alt="Screenshot 2025-07-02 at 15 53 11" src="https://github.com/user-attachments/assets/89da65e6-df8a-4019-b1ac-ef92ebcf38d5" />|<img width="357" alt="Screenshot 2025-07-02 at 15 52 36" src="https://github.com/user-attachments/assets/fc8d0e0e-6826-40f9-9832-ef633974b340" />|