### PR TITLE
TSDoc props component + table styling

### DIFF
--- a/css/tsdoc.css
+++ b/css/tsdoc.css
@@ -2,7 +2,7 @@
  * TSDoc props table
  * Overrides Nextra's default styling so the prop tables match the docs theme.
  *
- * Required custom properties (must be defined on :root by the consumer):
+ * Consumer-overridable tokens (defaults below; redefine on :root to retheme):
  *   --color-rb-fg-1          Primary foreground (table cell code text)
  *   --color-rb-fg-2          Secondary foreground (description text)
  *   --color-rb-fg-3          Tertiary foreground (column headers)
@@ -10,11 +10,24 @@
  *   --color-rb-bg-1          Base background (nested pre blocks)
  *   --color-rb-surface-2     Elevated surface (inline code background)
  *   --color-rb-hairline      Hairline border color
+ *   --color-rb-bad           Required-prop "*" marker
  *   --color-rb-cat-elements  Accent color (first-column pill, anchor hover);
  *                            row hover and pill tints are derived from this
  *                            via color-mix() so a single token re-themes both.
  *   --font-mono              Monospace stack (inline code)
  * ------------------------------------------------------------------------- */
+
+:root {
+  --color-rb-bg-1: #11111F;
+  --color-rb-surface-2: #1C1C2C;
+  --color-rb-fg-1: #F5F6FB;
+  --color-rb-fg-2: #B6BACB;
+  --color-rb-fg-3: #7E839A;
+  --color-rb-fg-muted: #565B73;
+  --color-rb-hairline: rgba(255, 255, 255, 0.07);
+  --color-rb-bad: #F87171;
+  --color-rb-cat-elements: #3B7BFF;
+}
 
 .tsdoc-props {
   margin: 1.5rem 0;
@@ -61,12 +74,14 @@
   background: transparent !important;
 }
 
-.tsdoc-props thead th:first-child {
-  width: 26%;
+.tsdoc-props th:first-child,
+.tsdoc-props td:first-child {
+  width: 22% !important;
 }
 
-.tsdoc-props thead th:nth-child(3) {
-  width: 18%;
+.tsdoc-props th:nth-child(3),
+.tsdoc-props td:nth-child(3) {
+  width: 26% !important;
 }
 
 .tsdoc-props tbody tr {
@@ -172,4 +187,18 @@
 .tsdoc-props tbody td:nth-child(3):empty::after {
   content: '—';
   color: var(--color-rb-fg-muted);
+}
+
+/* Required-prop marker.
+ * Nextra adds `after:content-["?"]` to optional name <code>s; the absence of
+ * that class means the prop is required, so we paint a red "*" after it. */
+.tsdoc-props tbody td:first-child code:not([class*="after:content"])::after {
+  content: '*';
+  margin-left: 0.15em;
+  color: var(--color-rb-bad, #ef4444);
+  font-weight: 700;
+  font-size: 0.85em;
+  vertical-align: super;
+  line-height: 0;
+  user-select: none;
 }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "reablocks-docs-theme",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "A Nextra theme for documentation reablocks site.",
   "repository": "https://github.com/reaviz/reablocks-docs-theme",
   "license": "MIT",
   "exports": {
     "./style.css": "./dist/style.css",
     "./style-prefixed.css": "./dist/style-prefixed.css",
+    "./tsdoc": {
+      "types": "./dist/tsdoc/index.d.mts",
+      "import": "./dist/tsdoc/index.js"
+    },
     ".": {
       "types": "./dist/index.d.mts",
       "import": "./dist/index.js"
@@ -47,6 +51,7 @@
     "react-syntax-highlighter": "^15.6.1",
     "scroll-into-view-if-needed": "^3.1.0",
     "tailwind-merge": "^3.3.1",
+    "ts-morph": "^27.0.2",
     "zod": "^4.4.3",
     "zod-validation-error": "^5.0.0",
     "zustand": "^5.0.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.6.0
+      ts-morph:
+        specifier: ^27.0.2
+        version: 27.0.2
       zod:
         specifier: ^4.4.3
         version: 4.4.3

--- a/src/tsdoc/index.tsx
+++ b/src/tsdoc/index.tsx
@@ -1,0 +1,121 @@
+import { generateDefinition, TSDoc } from 'nextra/tsdoc';
+import type { FC } from 'react';
+import { getOwnPropertyNames } from './own-props';
+
+export { getOwnPropertyNames } from './own-props';
+export type { GetOwnPropertyNamesArgs } from './own-props';
+
+export interface CreateTSDocPropsOptions {
+  /**
+   * Name of the source package to resolve types from (e.g. `'reablocks'`,
+   * `'reaviz'`). Used both as the module specifier in the generated TS code
+   * and to recognize which prop declarations are "own" vs inherited.
+   */
+  packageName: string;
+  /**
+   * Regex matched against each prop declaration's file path to identify
+   * properties declared by the source package (vs inherited from React,
+   * lib.dom, etc.). Defaults to `/\/${packageName}\/dist\//`.
+   */
+  ownPathPattern?: RegExp;
+}
+
+export interface TSDocPropsProps {
+  /**
+   * Component name. By default, resolves the `${name}Props` type re-exported
+   * from the configured package. When that lookup fails, automatically falls
+   * back to `React.ComponentProps<typeof name>` (unless `typeName` or
+   * `fromComponent` is set explicitly).
+   */
+  name: string;
+  /**
+   * Override the resolved type name. Defaults to `${name}Props`. Setting this
+   * disables the auto-fallback.
+   */
+  typeName?: string;
+  /**
+   * Resolve props via `React.ComponentProps<typeof name>` instead of the
+   * `${name}Props` re-export. Use for components whose props interface is
+   * declared but not exported from the package. Setting this disables the
+   * auto-fallback.
+   */
+  fromComponent?: boolean;
+  /**
+   * Include properties inherited from base types such as
+   * `React.HTMLAttributes`. Defaults to `false`.
+   */
+  includeInherited?: boolean;
+}
+
+/**
+ * Create a TSDocProps component bound to a specific source package. Each
+ * consumer site builds its own component:
+ *
+ * ```ts
+ * export const TSDocProps = createTSDocProps({ packageName: 'reablocks' });
+ * ```
+ *
+ * Renders a `<TSDoc>` props table wrapped in `<div className="tsdoc-props">`
+ * so the theme's CSS overrides apply.
+ *
+ * Server Component only — uses `ts-morph` and the TypeScript Compiler API.
+ */
+export const createTSDocProps = ({
+  packageName,
+  ownPathPattern
+}: CreateTSDocPropsOptions): FC<TSDocPropsProps> => {
+  const pathPattern = ownPathPattern ?? new RegExp(`/${packageName}/dist/`);
+
+  const namedExportCode = (name: string, typeName?: string) =>
+    `export { ${typeName ?? `${name}Props`} as default } from '${packageName}'`;
+
+  const componentPropsCode = (name: string) =>
+    `import { ${name} } from '${packageName}';
+import type { ComponentProps } from 'react';
+type _ResolvedProps = ComponentProps<typeof ${name}>;
+export { _ResolvedProps as default };`;
+
+  return function TSDocProps({
+    name,
+    typeName,
+    fromComponent = false,
+    includeInherited = false
+  }) {
+    let code = fromComponent
+      ? componentPropsCode(name)
+      : namedExportCode(name, typeName);
+    let definition;
+    try {
+      definition = generateDefinition({ code });
+    } catch (err) {
+      // Some packages declare `${name}Props` internally but don't export
+      // them (e.g. reaviz's `BrushProps`). Fall back to resolving via
+      // `React.ComponentProps<typeof ${name}>` so call sites don't need
+      // per-component `fromComponent`. Only kicks in when neither explicit
+      // mode is set.
+      if (fromComponent || typeName) throw err;
+      code = componentPropsCode(name);
+      definition = generateDefinition({ code });
+    }
+
+    let resolvedDefinition = definition;
+    if (!includeInherited && 'entries' in definition) {
+      const ownNames = getOwnPropertyNames({ code, pathPattern });
+      resolvedDefinition = {
+        ...definition,
+        entries: definition.entries.filter(entry => ownNames.has(entry.name))
+      };
+    }
+
+    return (
+      <div className="tsdoc-props">
+        <TSDoc definition={resolvedDefinition} typeLinkMap={SAFE_TYPE_LINK_MAP} />
+      </div>
+    );
+  };
+};
+
+// Nextra's `linkify` does `typeLinkMap[chunk]` against a plain `{}`, so chunks
+// matching `Object.prototype` methods (e.g. `toLocaleString`) resolve to a
+// function and get passed as `<Link href>`, crashing RSC serialization.
+const SAFE_TYPE_LINK_MAP = Object.create(null) as Record<string, string>;

--- a/src/tsdoc/own-props.ts
+++ b/src/tsdoc/own-props.ts
@@ -1,0 +1,54 @@
+import { Project } from 'ts-morph';
+
+const project = new Project({
+  tsConfigFilePath: './tsconfig.json',
+  skipAddingFilesFromTsConfig: true,
+  compilerOptions: {
+    exactOptionalPropertyTypes: true,
+    strictNullChecks: true
+  }
+});
+
+const VIRTUAL_FILENAME = '$tsdoc-props.ts';
+
+export interface GetOwnPropertyNamesArgs {
+  code: string;
+  pathPattern: RegExp;
+  exportName?: string;
+}
+
+// A prop is considered "own" only if at least one of its declarations lives
+// inside the configured package. Positive allowlist instead of a blocklist —
+// ts-morph in the Next.js build context sometimes returns no declarations at
+// all for deeply inherited symbols (React HTMLAttributes, lib.dom, etc.), and
+// a blocklist would let those pass through.
+export function getOwnPropertyNames({
+  code,
+  pathPattern,
+  exportName = 'default'
+}: GetOwnPropertyNamesArgs): Set<string> {
+  const sourceFile = project.createSourceFile(VIRTUAL_FILENAME, code, {
+    overwrite: true
+  });
+
+  const declaration = sourceFile.getExportedDeclarations().get(exportName)?.[0];
+  if (!declaration) {
+    throw new Error(
+      `Can't find "${exportName}" declaration while resolving own props`
+    );
+  }
+
+  const own = new Set<string>();
+  for (const prop of declaration.getType().getProperties()) {
+    const decls = prop.getDeclarations();
+    if (decls.length === 0) continue;
+    const hasOwnDecl = decls.some(d =>
+      pathPattern.test(d.getSourceFile().getFilePath())
+    );
+    if (hasOwnDecl) {
+      own.add(prop.getName());
+    }
+  }
+
+  return own;
+}


### PR DESCRIPTION
Adds a publishable `TSDocProps` Server Component for rendering Nextra TSDoc prop tables, plus theme defaults and a few CSS fixes for the table layout.

## Changes

**New `./tsdoc` entry point** (`src/tsdoc/index.tsx`, `src/tsdoc/own-props.ts`)
- `createTSDocProps({ packageName })` factory — each consumer site binds the component to its source package (`reablocks`, `reaviz`, etc.).
- Auto-fallback to `React.ComponentProps<typeof X>` when `${name}Props` isn't re-exported (e.g. reaviz's `BrushProps`); explicit `typeName` / `fromComponent` opts disable the fallback.
- `includeInherited` default `false` filters props down to those declared by the source package via a `ts-morph` positive-allowlist on declaration file paths — avoids leaking inherited React/lib.dom props.
- Uses an `Object.create(null)` `typeLinkMap` to dodge the RSC serialization crash from `Object.prototype` methods (`toLocaleString`, etc.) being treated as link targets.

**Package wiring** (`package.json`)
- New `./tsdoc` export (subpath; types + ESM import).
- Added `ts-morph` runtime dep.
- Version bumped to 2.3.2.

**CSS overrides** (`css/tsdoc.css`)
- Added `:root` token defaults so the theme works standalone; consumers can still re-theme by redefining tokens.
- Column widths now target `th` *and* `td` with `!important` to win over Nextra's responsive table reset.
- Added required-prop "*" marker that paints red after name `<code>`s missing Nextra's `after:content-["?"]` (optional) class.

## Why a separate `./tsdoc` subpath (and not the root entry)

- **Node-only / Server-Component-only.** The module pulls in `ts-morph` and reads `tsconfig.json` from disk. Re-exporting it from the root entry risks dragging Node-only code into client bundles for theme consumers that don't render TSDoc tables.
- **Heavy transitive footprint.** `ts-morph` ships the full TypeScript Compiler API. Keeping it behind an explicit subpath means consumers who never import `./tsdoc` don't pay the dependency cost in their build graph, even with `sideEffects: false`.
- **Explicit opt-in.** A separate import path signals "this is a build-time docs utility," distinct from the theme's runtime surface — easier to reason about for downstream sites.

## Notes

- Server Component only — pulls `ts-morph` + TS Compiler API.
- `getOwnPropertyNames` is also re-exported from `./tsdoc` for advanced use; no separate subpath export.
