### PR TITLE
Docs theme improvements across three areas: MDX-safe TSDoc rendering, and CSF1 story extraction.

### DIFF
--- a/css/tsdoc.css
+++ b/css/tsdoc.css
@@ -18,6 +18,10 @@
  * ------------------------------------------------------------------------- */
 
 :root {
+  /* Table panel background. Transparent by default so the table inherits the
+   * page background in both themes; override on a consumer :root to give the
+   * table its own distinct surface. */
+  --color-rb-surface-1: transparent;
   --color-rb-bg-1: #11111F;
   --color-rb-surface-2: #1C1C2C;
   --color-rb-fg-1: #F5F6FB;
@@ -29,8 +33,33 @@
   --color-rb-cat-elements: #3B7BFF;
 }
 
+/* Light theme overrides. The defaults above are tuned for dark backgrounds
+ * (a white hairline, dark surfaces, near-white text), which are invisible /
+ * low-contrast on a light page. Re-point the same tokens to light-appropriate
+ * values so the table borders, surfaces, and text stay legible under
+ * `html.light` (next-themes uses the `class` attribute). */
+html.light,
+html[data-theme='light'] {
+  /* `--color-rb-surface-1` stays `transparent` (inherited from `:root`) so the
+   * table picks up the page background (gray in light mode); code surfaces go
+   * white so they sit raised on it and stay high-contrast. */
+  --color-rb-bg-1: #ffffff;
+  --color-rb-surface-2: #ffffff;
+  --color-rb-fg-1: #1a1b2b; /* code text — ~16:1 on white */
+  --color-rb-fg-2: #4b5066; /* descriptions — ~7:1 on the gray panel */
+  --color-rb-fg-3: #565d7c; /* column headers — ~5.4:1 (AA for small caps) */
+  --color-rb-fg-muted: #6b7090; /* anchors / em-dash — ~4:1 */
+  --color-rb-hairline: rgba(17, 17, 31, 0.12);
+  --color-rb-bad: #dc2626;
+  --color-rb-cat-elements: #2563eb;
+}
+
 .tsdoc-props {
   margin: 1.5rem 0;
+  background-color: var(--color-rb-surface-1);
+  border: 1px solid var(--color-rb-hairline);
+  border-radius: 8px;
+  overflow: hidden;
 }
 
 .tsdoc-props table {
@@ -51,14 +80,24 @@
     display: table-row !important;
     margin: 0 !important;
     border: 0 !important;
+    border-top: 1px solid var(--color-rb-hairline) !important;
     border-radius: 0 !important;
     background: transparent !important;
+  }
+  /* Header's bottom border already separates the first row. */
+  .tsdoc-props tbody tr:first-child {
+    border-top: 0 !important;
   }
   .tsdoc-props tbody td {
     display: table-cell !important;
   }
   .tsdoc-props tbody td::before {
     content: none !important;
+  }
+  /* Vertical column dividers so the props list reads as a real bordered table. */
+  .tsdoc-props thead th:not(:last-child),
+  .tsdoc-props tbody td:not(:last-child) {
+    border-right: 1px solid var(--color-rb-hairline) !important;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reablocks-docs-theme",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A Nextra theme for documentation reablocks site.",
   "repository": "https://github.com/reaviz/reablocks-docs-theme",
   "license": "MIT",

--- a/src/api/story-source/get-story-source.ts
+++ b/src/api/story-source/get-story-source.ts
@@ -2,6 +2,15 @@ import { NextResponse } from 'next/server';
 import { readFileSync } from 'fs';
 
 /**
+ * Escapes regex metacharacters so a dynamic value (e.g. an export name) can be
+ * interpolated into a `RegExp` literally without breaking the pattern.
+ * @param value - The raw string to escape
+ * @returns The string with all regex special characters backslash-escaped
+ */
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
  * Extracts the component name from the story file
  * @param fileContent - The content of the story file
  * @returns The component name
@@ -161,9 +170,13 @@ export const getStorySource = async (storyPath: string, functionName: string) =>
     // Extract component name from default export
     const componentName = extractComponentName(fileContent);
 
+    // Escape the export name before interpolating it into any RegExp so names
+    // with regex metacharacters can't break or alter the patterns below.
+    const escapedName = escapeRegExp(functionName);
+
     // Try to extract as function first (arrow function format)
     const functionRegex = new RegExp(
-      `export\\s+const\\s+${functionName}\\s*=\\s*\\([^)]*\\)\\s*=>\\s*([\\s\\S]*?)(?=\\nexport|$)`,
+      `export\\s+const\\s+${escapedName}\\s*=\\s*\\([^)]*\\)\\s*=>\\s*([\\s\\S]*?)(?=\\nexport|$)`,
       'g'
     );
 
@@ -183,7 +196,7 @@ export const getStorySource = async (storyPath: string, functionName: string) =>
 
     // Try to extract as CSF story object (Storybook format)
     // Use a more precise approach to capture the entire story object
-    const storyPattern = `export\\s+const\\s+${functionName}\\s*:[^=]*=\\s*\\{`;
+    const storyPattern = `export\\s+const\\s+${escapedName}\\s*:[^=]*=\\s*\\{`;
     const storyStartMatch = fileContent.match(new RegExp(storyPattern));
 
     let storyObject = '';
@@ -231,7 +244,7 @@ export const getStorySource = async (storyPath: string, functionName: string) =>
     // Fallback regex without type annotation
     if (!objectFound) {
       const fallbackRegex = new RegExp(
-        `export\\s+const\\s+${functionName}\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*;?`,
+        `export\\s+const\\s+${escapedName}\\s*=\\s*\\{([\\s\\S]*?)\\}\\s*;?`,
         'g'
       );
       const objectMatch = fallbackRegex.exec(fileContent);
@@ -366,6 +379,68 @@ export const getStorySource = async (storyPath: string, functionName: string) =>
       }
 
       // Story object without args or render function - fallback
+      const result = `(args) => <${componentName} {...args} />;`;
+      return NextResponse.json({ source: result });
+    }
+
+    // Try to extract as Storybook CSF1 Template.bind({}) pattern:
+    //   const Template = (args) => <Component {...args} />;
+    //   export const Basic = Template.bind({});
+    //   Basic.args = { ... };
+    const bindRegex = new RegExp(
+      `export\\s+const\\s+${escapedName}\\s*(?::[^=]+)?=\\s*[A-Za-z_$][A-Za-z0-9_$]*\\s*\\.bind\\s*\\(`
+    );
+    if (bindRegex.test(fileContent)) {
+      const argsAssignment = new RegExp(
+        `${escapedName}\\.args\\s*=\\s*\\{`
+      ).exec(fileContent);
+
+      if (argsAssignment) {
+        const startIndex = argsAssignment.index + argsAssignment[0].length - 1;
+        let braceCount = 0;
+        let endIndex = -1;
+        let inString = false;
+        let stringChar = '';
+
+        for (let i = startIndex; i < fileContent.length; i++) {
+          const char = fileContent[i];
+
+          // Inside a string, a backslash escapes the next character — skip
+          // both so an escaped quote (`\"`) or escaped backslash (`\\`) before
+          // a quote doesn't get mistaken for a string terminator.
+          if (inString && char === '\\') {
+            i++;
+            continue;
+          }
+
+          if (!inString && (char === '"' || char === "'" || char === '`')) {
+            inString = true;
+            stringChar = char;
+          } else if (inString && char === stringChar) {
+            inString = false;
+          } else if (!inString) {
+            if (char === '{') {
+              braceCount++;
+            } else if (char === '}') {
+              braceCount--;
+              if (braceCount === 0) {
+                endIndex = i;
+                break;
+              }
+            }
+          }
+        }
+
+        if (endIndex !== -1) {
+          const argsContent = fileContent.substring(startIndex + 1, endIndex).trim();
+          const result = argsContent
+            ? generateCSFStorySource(componentName, argsContent)
+            : `(args) => <${componentName} {...args} />;`;
+          return NextResponse.json({ source: result });
+        }
+      }
+
+      // bind() match but no .args assignment found — fall back to spread template
       const result = `(args) => <${componentName} {...args} />;`;
       return NextResponse.json({ source: result });
     }

--- a/src/tsdoc/escape-mdx.test.ts
+++ b/src/tsdoc/escape-mdx.test.ts
@@ -1,0 +1,84 @@
+import { escapeDefinitionDescriptions, escapeMdxBraces } from './escape-mdx';
+
+describe('escapeMdxBraces', () => {
+  it('escapes object-literal examples in prose', () => {
+    expect(
+      escapeMdxBraces('For example { preserveDrawingBuffer: true }')
+    ).toBe('For example \\{ preserveDrawingBuffer: true \\}');
+  });
+
+  it('leaves text without braces untouched', () => {
+    expect(escapeMdxBraces('A plain description.')).toBe('A plain description.');
+  });
+
+  it('does not escape braces inside inline code spans', () => {
+    expect(escapeMdxBraces('Pass `{ a: 1 }` to enable it')).toBe(
+      'Pass `{ a: 1 }` to enable it'
+    );
+  });
+
+  it('does not escape braces inside fenced code spans', () => {
+    const input = '```\nconst x = { a: 1 }\n```';
+    expect(escapeMdxBraces(input)).toBe(input);
+  });
+
+  it('escapes braces outside code while preserving those inside', () => {
+    expect(escapeMdxBraces('use {x} or `{y}`')).toBe('use \\{x\\} or `{y}`');
+  });
+});
+
+describe('escapeDefinitionDescriptions', () => {
+  it('escapes braces in entry descriptions and the description tag', () => {
+    const result = escapeDefinitionDescriptions({
+      name: 'GraphCanvas',
+      entries: [
+        {
+          name: 'glOptions',
+          type: 'object',
+          description: 'For example { preserveDrawingBuffer: true }'
+        },
+        {
+          name: 'deprecatedProp',
+          type: 'string',
+          tags: { deprecated: 'use {newProp} instead', default: '{}' }
+        }
+      ]
+    });
+
+    expect(result.entries[0]!.description).toBe(
+      'For example \\{ preserveDrawingBuffer: true \\}'
+    );
+    // `deprecated` is rendered as markdown → escaped;
+    // `default` is emitted as code → left untouched.
+    expect(result.entries[1]!.tags).toEqual({
+      deprecated: 'use \\{newProp\\} instead',
+      default: '{}'
+    });
+  });
+
+  it('escapes function signature param and return descriptions', () => {
+    const result = escapeDefinitionDescriptions({
+      name: 'doThing',
+      signatures: [
+        {
+          params: [
+            { name: 'opts', type: 'object', description: 'shape { a: 1 }' }
+          ],
+          returns: [{ name: 'result', type: 'object', description: 'a {b}' }]
+        }
+      ]
+    });
+
+    expect(result.signatures[0]!.params[0]!.description).toBe('shape \\{ a: 1 \\}');
+    expect(result.signatures[0]!.returns[0]!.description).toBe('a \\{b\\}');
+  });
+
+  it('does not mutate the input definition', () => {
+    const input = {
+      name: 'X',
+      entries: [{ name: 'a', type: 'object', description: '{x}' }]
+    };
+    escapeDefinitionDescriptions(input);
+    expect(input.entries[0]!.description).toBe('{x}');
+  });
+});

--- a/src/tsdoc/escape-mdx.ts
+++ b/src/tsdoc/escape-mdx.ts
@@ -1,0 +1,80 @@
+import type { GeneratedDefinition, Tags, TypeField } from 'nextra/tsdoc';
+
+/**
+ * Nextra's `TSDoc` renders every description (props, params, returns) through
+ * the MDX compiler, so a bare `{` in a TSDoc comment is parsed as a JSX
+ * expression. Upstream descriptions sometimes include object-literal examples
+ * such as `{ preserveDrawingBuffer: true }`, which aren't valid expressions and
+ * crash the build with "Could not parse expression with acorn".
+ *
+ * Escape `{`/`}` that sit in prose while leaving code spans — inline (`` `…` ``)
+ * and fenced (```` ``` ````) — untouched, since MDX already treats those
+ * literally and escaping inside them would surface the backslash.
+ */
+export const escapeMdxBraces = (text: string): string =>
+  text.replace(/(`+)[\s\S]*?\1|[{}]/g, match =>
+    match[0] === '`' ? match : `\\${match}`
+  );
+
+const sanitizeTags = (tags: Tags | undefined): Tags | undefined => {
+  if (!tags) {
+    return tags;
+  }
+  const next: Tags = { ...tags };
+  // Only `description` and `deprecated` are rendered as markdown; other tags
+  // (e.g. `default`) are emitted as plain code and must not be escaped.
+  for (const key of ['description', 'deprecated'] as const) {
+    if (typeof next[key] === 'string') {
+      next[key] = escapeMdxBraces(next[key]);
+    }
+  }
+  return next;
+};
+
+const sanitizeTypeField = (field: TypeField): TypeField => ({
+  ...field,
+  description:
+    typeof field.description === 'string'
+      ? escapeMdxBraces(field.description)
+      : field.description,
+  tags: sanitizeTags(field.tags)
+});
+
+/**
+ * Return a copy of a generated definition with every markdown-rendered
+ * description escaped so the MDX compiler treats stray braces literally.
+ */
+export const escapeDefinitionDescriptions = <T extends GeneratedDefinition>(
+  definition: T
+): T => {
+  const next = { ...definition } as T & {
+    description?: string;
+    tags?: Tags;
+    entries?: TypeField[];
+    signatures?: {
+      params: TypeField[];
+      returns: TypeField[] | { type: string };
+    }[];
+  };
+
+  if (typeof next.description === 'string') {
+    next.description = escapeMdxBraces(next.description);
+  }
+  if (next.tags) {
+    next.tags = sanitizeTags(next.tags);
+  }
+  if (Array.isArray(next.entries)) {
+    next.entries = next.entries.map(sanitizeTypeField);
+  }
+  if (Array.isArray(next.signatures)) {
+    next.signatures = next.signatures.map(signature => ({
+      ...signature,
+      params: signature.params.map(sanitizeTypeField),
+      returns: Array.isArray(signature.returns)
+        ? signature.returns.map(sanitizeTypeField)
+        : signature.returns
+    }));
+  }
+
+  return next;
+};

--- a/src/tsdoc/index.tsx
+++ b/src/tsdoc/index.tsx
@@ -1,6 +1,9 @@
 import { generateDefinition, TSDoc } from 'nextra/tsdoc';
 import type { FC } from 'react';
+import { escapeDefinitionDescriptions } from './escape-mdx';
 import { getOwnPropertyNames } from './own-props';
+
+export { escapeMdxBraces, escapeDefinitionDescriptions } from './escape-mdx';
 
 export { getOwnPropertyNames } from './own-props';
 export type { GetOwnPropertyNamesArgs } from './own-props';
@@ -109,7 +112,10 @@ export { _ResolvedProps as default };`;
 
     return (
       <div className="tsdoc-props">
-        <TSDoc definition={resolvedDefinition} typeLinkMap={SAFE_TYPE_LINK_MAP} />
+        <TSDoc
+          definition={escapeDefinitionDescriptions(resolvedDefinition)}
+          typeLinkMap={SAFE_TYPE_LINK_MAP}
+        />
       </div>
     );
   };


### PR DESCRIPTION
### TSDoc MDX escaping (`src/tsdoc/`)
- New `escape-mdx.ts`: escapes stray `{`/`}` in TSDoc descriptions before Nextra's `TSDoc` renders them through MDX, so object-literal examples (e.g. `{ preserveDrawingBuffer: true }`) no longer crash the build. Code spans (inline + fenced) are left untouched.
- Only markdown-rendered tags (`description`, `deprecated`) are escaped; code-emitted tags (`default`) are preserved verbatim.
- `index.tsx` runs the resolved definition through `escapeDefinitionDescriptions` before rendering.
- Full unit coverage in `escape-mdx.test.ts` (prose, code spans, signatures, immutability).

### Light-theme table styling (`css/tsdoc.css`)
- Added `html.light` / `html[data-theme='light']` token overrides so table borders, surfaces, and text stay legible on light backgrounds (documented contrast ratios).
- Added bordered table panel: outer border, radius, row dividers, and vertical column dividers.

### CSF1 story extraction (`src/api/story-source/get-story-source.ts`)
- Added support for the Storybook `Template.bind({})` + `.args` pattern, with brace/string-aware args extraction.
- Added an `escapeRegExp` helper applied to all dynamic `functionName` interpolations so export names with regex metacharacters can't break the patterns.
- String scanner skips backslash-escaped characters so escaped quotes don't terminate strings early.
